### PR TITLE
Support statement cache

### DIFF
--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -12,7 +12,7 @@ repos:
   - id: black
     language_version: python3
 - repo: https://github.com/pycqa/isort
-  rev: 5.11.4
+  rev: 5.12.0
   hooks:
   - id: isort
     args: ["--profile", "black"]

--- a/sqlalchemy_rdsiam/dialects.py
+++ b/sqlalchemy_rdsiam/dialects.py
@@ -27,6 +27,11 @@ try:
     _has_sqlalchemy_psycopg2 = True
 
     class PGDialect_psycopg2rdsiam(PGDialect_psycopg2):
+
+        supports_statement_cache = PGDialect_psycopg2.__dict__.get(
+            "supports_statement_cache", None
+        )
+
         @classmethod
         def dbapi(cls: Type) -> ModuleType:
             return cls.import_dbapi()
@@ -66,6 +71,11 @@ try:
     _has_sqlalchemy_asyncpg = True
 
     class PGDialect_asyncpgrdsiam(PGDialect_asyncpg):
+
+        supports_statement_cache = PGDialect_asyncpg.__dict__.get(
+            "supports_statement_cache", None
+        )
+
         @classmethod
         def dbapi(cls: Type) -> ModuleType:
             return cls.import_dbapi()

--- a/tox.ini
+++ b/tox.ini
@@ -24,18 +24,18 @@ commands = pytest -s {posargs}
 passenv = PGPASSWORD
 deps =
     sa13: sqlalchemy==1.3.24
-    sa13: psycopg2-binary==2.9.3
-    sa13: asyncpg==0.27.0
-    sa14: sqlalchemy==1.4.45
-    sa14: psycopg2-binary==2.9.3
-    sa14: asyncpg==0.27.0
-    sa14asyncpgonly: sqlalchemy==1.4.45
-    sa14asyncpgonly: asyncpg==0.27.0
-    sa14psycopg2only: sqlalchemy==1.4.45
-    sa14psycopg2only: psycopg2-binary==2.9.3
-    sa20: sqlalchemy==2.0.0b4
-    sa20: psycopg2-binary==2.9.3
-    sa20: asyncpg==0.27.0
+    sa13: psycopg2-binary==2.9.7
+    sa13: asyncpg==0.28.0
+    sa14: sqlalchemy==1.4.49
+    sa14: psycopg2-binary==2.9.7
+    sa14: asyncpg==0.28.0
+    sa14asyncpgonly: sqlalchemy==1.4.49
+    sa14asyncpgonly: asyncpg==0.28.0
+    sa14psycopg2only: sqlalchemy==1.4.49
+    sa14psycopg2only: psycopg2-binary==2.9.7
+    sa20: sqlalchemy==2.0.20
+    sa20: psycopg2-binary==2.9.7
+    sa20: asyncpg==0.28.0
     boto3==1.22.13
     cryptography==37.0.2 # For unit tests
     pytest==7.1.2


### PR DESCRIPTION
## Description

When using SQLAlchemy > 1.4 with the dialects available here we get the following warning:

```
sqlalchemy.exc.SAWarning: Dialect database:driver will not make use of SQL
compilation caching as it does not set the 'supports_statement_cache'
attribute to ``True``. This can have significant performance implications
including some performance degradations in comparison to prior SQLAlchemy
versions. Dialect maintainers should seek to set this attribute to True
after appropriate development and testing for SQLAlchemy 1.4 caching
support. Alternatively, this attribute may be set to False which will
disable this warning.
```

The dialects we inherit from (`PGDialect_asyncpg`, `PGDiaclect_psycopg2`) support statement caching, so our Dialects do to. However, this needs to be explicitly indicated in our Dialect class to be enabled in SQLAlchemy.

We therefore propagate the `support_statement_cache` value from the Dialect we inherit from if it is explicitly set there (for compatibility with older versions).

## Type of Change

- [X] Bug Fix

## Checklist

<!-- TODO: Update the link below to point to your project's contributing guidelines -->
- [X] I have read the [contributing guidelines](/CONTRIBUTING.md)
- [X] Existing issues have been referenced (where applicable)
- [X] I have verified this change is not present in other open pull requests
- [X] Functionality is documented
- [X] All code style checks pass
- [ ] New code contribution is covered by automated tests
- [X] All new and existing tests pass
