### PR TITLE
Fix python < 3.8 compatibility

### DIFF
--- a/sqlalchemy_rdsiam/rds.py
+++ b/sqlalchemy_rdsiam/rds.py
@@ -21,6 +21,6 @@ from typing import Any
 import boto3
 
 
-@functools.lru_cache
+@functools.lru_cache()
 def rds_client(region_name: str) -> Any:
     return boto3.client("rds", region_name=region_name)


### PR DESCRIPTION
## Description

The `lru_cache` decorator must be explicitly called for python versions < 3.8 (`@lru_cache()` must be used instead of `@lru_cache`)

See https://docs.python.org/3/library/functools.html#functools.lru_cache
> Changed in version 3.8: Added the user_function option.

## Type of Change

- [X] Bug Fix

## Checklist

<!-- TODO: Update the link below to point to your project's contributing guidelines -->
- [X] I have read the [contributing guidelines](/CONTRIBUTING.md)
- [X] Existing issues have been referenced (where applicable)
- [X] I have verified this change is not present in other open pull requests
- [X] Functionality is documented
- [ ] All code style checks pass
- [ ] New code contribution is covered by automated tests
- [ ] All new and existing tests pass
